### PR TITLE
Move pnpm version to package metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: 10.34.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "musicview",
 	"version": "0.1.0",
 	"private": true,
+	"packageManager": "pnpm@11.9.0",
 	"scripts": {
 		"dev": "next dev --turbopack",
 		"build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true
+packages:
+  - .


### PR DESCRIPTION
## Summary
- move the pnpm version out of the CI workflow and into package.json packageManager
- add pnpm v11 build-script approvals for esbuild, sharp, and workerd

## Validation
- CI=true pnpm install --frozen-lockfile
- CI=true pnpm run lint
- CI=true pnpm run fmt:check
- CI=true pnpm run typecheck
- CI=true pnpm run build