### PR TITLE
Centralize Node.js version configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24
+          node-version-file: package.json
           cache: pnpm
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "musicview",
 	"version": "0.1.0",
 	"private": true,
+	"engines": {
+		"node": "24.x"
+	},
 	"packageManager": "pnpm@11.10.0",
 	"scripts": {
 		"dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- define Node.js 24.x in `package.json` as the repository source of truth
- configure `actions/setup-node` to read `package.json`
- pin `actions/setup-node` v6 to its commit SHA, matching the repository's existing action pinning policy

## Why

The CI workflow directly specified Node.js 24 while the repository had no Node.js version source of truth. This removes the duplicated workflow-owned version and keeps the existing Node.js 24 compatibility target.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm run lint`
- `CI=true pnpm run fmt:check`
- `CI=true pnpm run typecheck`
- `CI=true pnpm run build`
- `actionlint`
- `pinact run --check`
- `zizmor --format plain .`