### PR TITLE
Hold TypeScript major updates until Next.js support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,17 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>blck-snwmn/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Hold TypeScript major updates until Next.js supports TypeScript 7",
+      "matchPackageNames": [
+        "typescript"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- hold TypeScript major updates in Renovate
- keep TypeScript 6 updates enabled
- avoid bypassing Next.js build-time type checking

## Context

PR #57 installs TypeScript 7 successfully and passes the standalone type check, but Next.js 16.2.10 still requires the legacy `typescript/lib/typescript.js` API entrypoint during `next build`. TypeScript 7 no longer ships that entrypoint.

The latest stable Next.js release is still 16.2.10. Until a stable Next.js release supports the TypeScript 7 CLI-only package layout, this repository should not propose TypeScript major updates.

## Validation

- `npx --yes --package renovate renovate-config-validator renovate.json`
- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm run lint`
- `CI=true pnpm run fmt:check`
- `CI=true XDG_CONFIG_HOME=/private/tmp/musicview-wrangler pnpm run cf-typegen:check`
- `CI=true pnpm run typecheck`
- `CI=true pnpm run build`