### PR TITLE
Update pnpm to 11.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"node": "24.x"
 	},
-	"packageManager": "pnpm@11.11.0",
+	"packageManager": "pnpm@11.13.0",
 	"scripts": {
 		"dev": "next dev --turbopack",
 		"build": "next build",


### PR DESCRIPTION
## Summary

- update the repository-managed pnpm version from 11.11.0 to 11.13.0
- keep the workflow reading the version from `package.json`

## Root cause

pnpm 11.12.0 fails during the `pnpm/action-setup` self-installer update path before dependency installation. pnpm 11.13.0 contains the corrected published package structure for this path.

## Validation

- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm run lint`
- `pnpm run fmt:check`
- `pnpm run cf-typegen`
- `pnpm run cf-typegen:check`
- `pnpm run typecheck`
- `pnpm run build`
- `aqua exec -- pinact run --check`
- `aqua exec -- zizmor .github/workflows`

The lockfile and generated Cloudflare types remain unchanged.
